### PR TITLE
CA-4439 Remove deprecated restock field on shopify refund

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.channelape</groupId>
 	<artifactId>shopify-sdk</artifactId>
-	<version>1.2.3-SNAPSHOT</version>
+	<version>1.2.4-SNAPSHOT</version>
 
 	<name>Shopify SDK</name>
 	<description>Java SDK for Shopify REST API.</description>

--- a/src/main/java/com/shopify/model/ShopifyRefund.java
+++ b/src/main/java/com/shopify/model/ShopifyRefund.java
@@ -30,7 +30,6 @@ public class ShopifyRefund {
 	@XmlElement(name = "processed_at")
 	@XmlJavaTypeAdapter(DateTimeAdapter.class)
 	private DateTime processedAt;
-	private boolean restock;
 	@XmlElement(name = "refund_line_items")
 	private List<ShopifyRefundLineItem> refundLineItems;
 	private ShopifyRefundShippingDetails shipping;
@@ -92,14 +91,6 @@ public class ShopifyRefund {
 
 	public void setProcessedAt(final DateTime processedAt) {
 		this.processedAt = processedAt;
-	}
-
-	public boolean isRestock() {
-		return restock;
-	}
-
-	public void setRestock(final boolean restock) {
-		this.restock = restock;
 	}
 
 	public ShopifyRefundShippingDetails getShipping() {

--- a/src/test/java/com/shopify/ShopifySdkTest.java
+++ b/src/test/java/com/shopify/ShopifySdkTest.java
@@ -307,7 +307,6 @@ public class ShopifySdkTest {
 		shopifyRefund1.setId("87128371823");
 		shopifyRefund1.setNote("Customer didn't want");
 		shopifyRefund1.setOrderId("someId");
-		shopifyRefund1.setRestock(false);
 		shopifyRefund1.setUserId(null);
 
 		final ShopifyRefundLineItem shopifyRefundedLineItem = new ShopifyRefundLineItem();
@@ -1808,7 +1807,6 @@ public class ShopifySdkTest {
 		shopifyRefund.setCurrency(Currency.getInstance("USD"));
 		shopifyRefund.setId("999999");
 		shopifyRefund.setOrderId("123123");
-		shopifyRefund.setRestock(false);
 
 		final ShopifyRefundShippingDetails shipping = new ShopifyRefundShippingDetails();
 		shipping.setAmount(new BigDecimal(99.11));

--- a/src/test/java/com/shopify/ShopifySdkTest.java
+++ b/src/test/java/com/shopify/ShopifySdkTest.java
@@ -1859,7 +1859,6 @@ public class ShopifySdkTest {
 
 		assertEquals("999999", calculateRequestBody.getContent().get("refund").get("id").asText());
 		assertEquals("123123", calculateRequestBody.getContent().get("refund").get("order_id").asText());
-		assertEquals(false, calculateRequestBody.getContent().get("refund").get("restock").asBoolean());
 		assertEquals("USD", calculateRequestBody.getContent().get("refund").get("currency").asText());
 		assertEquals(SOME_DATE_TIME.toString(),
 				calculateRequestBody.getContent().get("refund").get("created_at").asText());
@@ -1901,7 +1900,6 @@ public class ShopifySdkTest {
 
 		assertEquals("999999", refundRequestBody.getContent().get("refund").get("id").asText());
 		assertEquals("123123", refundRequestBody.getContent().get("refund").get("order_id").asText());
-		assertEquals(false, refundRequestBody.getContent().get("refund").get("restock").asBoolean());
 		assertEquals("USD", refundRequestBody.getContent().get("refund").get("currency").asText());
 		assertEquals(SOME_DATE_TIME.toString(),
 				refundRequestBody.getContent().get("refund").get("created_at").asText());


### PR DESCRIPTION
According to the shopify docs, the 'restock' parameter is deprecated. We use the new restock_type on the refunded line items

https://help.shopify.com/en/api/reference/orders/refund#properties