### PR TITLE
#43 Fixes string error responses when performing multiple readEntity(String.class)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.channelape</groupId>
 	<artifactId>shopify-sdk</artifactId>
-	<version>2.0.0</version>
+	<version>2.1.0.ERROR_RESPONSE-SNAPSHOT</version>
 
 	<name>Shopify SDK</name>
 	<description>Java SDK for Shopify REST API.</description>
@@ -94,6 +94,12 @@
 			<artifactId>commons-lang3</artifactId>
 			<version>3.4</version>
 		</dependency>
+		<dependency>
+		    <groupId>org.apache.commons</groupId>
+		    <artifactId>commons-io</artifactId>
+		    <version>1.3.2</version>
+		</dependency>
+				
 		<dependency>
 			<groupId>joda-time</groupId>
 			<artifactId>joda-time</artifactId>

--- a/src/main/java/com/shopify/ShopifySdk.java
+++ b/src/main/java/com/shopify/ShopifySdk.java
@@ -37,6 +37,7 @@ import com.github.rholder.retry.StopStrategies;
 import com.github.rholder.retry.WaitStrategies;
 import com.shopify.exceptions.ShopifyClientException;
 import com.shopify.exceptions.ShopifyErrorResponseException;
+import com.shopify.mappers.ResponseEntityToStringMapper;
 import com.shopify.mappers.ShopifySdkObjectMapper;
 import com.shopify.model.Count;
 import com.shopify.model.Image;
@@ -996,9 +997,8 @@ public class ShopifySdk {
 	}
 
 	private static boolean hasNotBeenSaved(final Response response) {
-		response.bufferEntity();
 		if ((UNPROCESSABLE_ENTITY_STATUS_CODE == response.getStatus()) && response.hasEntity()) {
-			final String shopifyErrorResponse = response.readEntity(String.class);
+			final String shopifyErrorResponse = ResponseEntityToStringMapper.map(response);
 			LOGGER.debug(shopifyErrorResponse);
 			return shopifyErrorResponse.contains(COULD_NOT_BE_SAVED_SHOPIFY_ERROR_MESSAGE);
 		}
@@ -1064,8 +1064,7 @@ public class ShopifySdk {
 			if (attempt.hasResult()) {
 				final Response response = (Response) attempt.getResult();
 
-				response.bufferEntity();
-				final String responseBody = response.readEntity(String.class);
+				final String responseBody = ResponseEntityToStringMapper.map(response);
 
 				if (LOGGER.isWarnEnabled() && !hasExceededRateLimit(response) && shouldRetryResponse(response)) {
 

--- a/src/main/java/com/shopify/exceptions/ShopifyErrorResponseException.java
+++ b/src/main/java/com/shopify/exceptions/ShopifyErrorResponseException.java
@@ -4,6 +4,8 @@ import java.util.List;
 
 import javax.ws.rs.core.Response;
 
+import com.shopify.mappers.ResponseEntityToStringMapper;
+
 public class ShopifyErrorResponseException extends RuntimeException {
 
 	static final String MESSAGE = "Received unexpected Response Status Code of %d\nResponse Headers of:\n%s\nResponse Body of:\n%s";
@@ -14,15 +16,13 @@ public class ShopifyErrorResponseException extends RuntimeException {
 
 	public ShopifyErrorResponseException(final Response response) {
 		super(buildMessage(response));
-		response.bufferEntity();
-		this.responseBody = response.readEntity(String.class);
+		this.responseBody = ResponseEntityToStringMapper.map(response);
 		this.shopifyErrorCodes = ShopifyErrorCodeFactory.create(responseBody);
 		this.statusCode = response.getStatus();
 	}
 
 	private static String buildMessage(final Response response) {
-		response.bufferEntity();
-		final String readEntity = response.readEntity(String.class);
+		final String readEntity = ResponseEntityToStringMapper.map(response);
 		return String.format(MESSAGE, response.getStatus(), response.getStringHeaders(), readEntity);
 	}
 

--- a/src/main/java/com/shopify/mappers/ResponseEntityToStringMapper.java
+++ b/src/main/java/com/shopify/mappers/ResponseEntityToStringMapper.java
@@ -1,0 +1,42 @@
+package com.shopify.mappers;
+
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+import javax.ws.rs.core.Response;
+
+import org.apache.commons.io.IOUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ResponseEntityToStringMapper {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(ResponseEntityToStringMapper.class);
+
+	private ResponseEntityToStringMapper() {
+	}
+
+	/**
+	 * JAXRS Jersey Client implementation closes stream buffers when reading entity
+	 * by string. To combat this and be able to read entities via a string more than
+	 * once, this deals with the input streams involved and resets where necessary.
+	 *
+	 * @param response
+	 * @return
+	 */
+	public static String map(final Response response) {
+
+		try {
+			response.bufferEntity();
+			final InputStream entityBytes = (InputStream) response.getEntity();
+			final String responseBody = IOUtils.toString(entityBytes, StandardCharsets.UTF_8.toString());
+			entityBytes.reset();
+			return responseBody;
+		} catch (final Exception e) {
+			LOGGER.error("There was an error parsing response body on response with status {}, returning null",
+					response.getStatus());
+			return null;
+		}
+	}
+
+}

--- a/src/test/java/com/shopify/ShopifySdkDriver.java
+++ b/src/test/java/com/shopify/ShopifySdkDriver.java
@@ -9,6 +9,7 @@ import static org.junit.Assert.assertTrue;
 import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Random;
 import java.util.UUID;
@@ -662,6 +663,19 @@ public class ShopifySdkDriver {
 
 		final ShopifyCustomer updatedCustomer = shopifySdk.updateCustomer(shopifyOrderUpdateRequest);
 		assertEquals("RyanTest", updatedCustomer.getFirstName());
+	}
+
+	@Test
+	public void givenSomeErrorOccurrsWhenCreatingFulfillmentThenExpectCorrectErrors() {
+		try {
+			shopifySdk.createFulfillment(ShopifyFulfillmentCreationRequest.newBuilder().withOrderId("2854620102717")
+					.withTrackingCompany("UPS").withTrackingNumber("ABC-123").withNotifyCustomer(false)
+					.withLineItems(new LinkedList<>()).withLocationId("5523767400")
+					.withTrackingUrls(Arrays.asList("http://google.com/123")).build());
+		} catch (final Exception e) {
+			e.printStackTrace();
+		}
+
 	}
 
 	@After

--- a/src/test/java/com/shopify/exceptions/ShopifyErrorResponseExceptionTest.java
+++ b/src/test/java/com/shopify/exceptions/ShopifyErrorResponseExceptionTest.java
@@ -5,6 +5,9 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 
 import javax.ws.rs.core.MultivaluedHashMap;
@@ -32,7 +35,9 @@ public class ShopifyErrorResponseExceptionTest {
 		when(response.getStringHeaders()).thenReturn(responseHeaders);
 
 		final String expectedResponseBodyString = "{\"error\": \"something went wrong.\"}";
-		when(response.readEntity(String.class)).thenReturn(expectedResponseBodyString);
+		final InputStream expectedResponseStream = new ByteArrayInputStream(
+				expectedResponseBodyString.getBytes(StandardCharsets.UTF_8));
+		when(response.getEntity()).thenReturn(expectedResponseStream);
 
 		final ShopifyErrorResponseException actualShopifyErrorResponseException = new ShopifyErrorResponseException(
 				response);
@@ -65,7 +70,9 @@ public class ShopifyErrorResponseExceptionTest {
 		when(response.getStringHeaders()).thenReturn(responseHeaders);
 
 		final String expectedResponseBodyString = "Some unaprseable error";
-		when(response.readEntity(String.class)).thenReturn(expectedResponseBodyString);
+		final InputStream expectedResponseStream = new ByteArrayInputStream(
+				expectedResponseBodyString.getBytes(StandardCharsets.UTF_8));
+		when(response.getEntity()).thenReturn(expectedResponseStream);
 		final ShopifyErrorResponseException actualShopifyErrorResponseException = new ShopifyErrorResponseException(
 				response);
 
@@ -100,7 +107,9 @@ public class ShopifyErrorResponseExceptionTest {
 				+ "            \"address1 can't be blank, zip is not valid for united states, and city can't be blank\"\n"
 				+ "        ]\n" + "    }\n" + "}";
 
-		when(response.readEntity(String.class)).thenReturn(expectedResponseBodyString);
+		final InputStream expectedResponseStream = new ByteArrayInputStream(
+				expectedResponseBodyString.getBytes(StandardCharsets.UTF_8));
+		when(response.getEntity()).thenReturn(expectedResponseStream);
 		final ShopifyErrorResponseException actualShopifyErrorResponseException = new ShopifyErrorResponseException(
 				response);
 

--- a/src/test/java/com/shopify/mappers/ResponseEntityToStringMapperTest.java
+++ b/src/test/java/com/shopify/mappers/ResponseEntityToStringMapperTest.java
@@ -1,0 +1,41 @@
+package com.shopify.mappers;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+import javax.ws.rs.core.Response;
+
+import org.junit.Test;
+
+public class ResponseEntityToStringMapperTest {
+
+	@Test
+	public void givenSomeValuesWhenMappingResponseEntityToAStringThenExpectCorrectValues() throws Exception {
+		final Response response = mock(Response.class);
+
+		final String expectedResponseBodyString = "{\"error\": \"something went wrong.\"}";
+		final InputStream expectedResponseStream = new ByteArrayInputStream(
+				expectedResponseBodyString.getBytes(StandardCharsets.UTF_8));
+		when(response.getEntity()).thenReturn(expectedResponseStream);
+		final String actualResponseBodyString = ResponseEntityToStringMapper.map(response);
+		assertEquals(expectedResponseBodyString, actualResponseBodyString);
+
+	}
+
+	@Test
+	public void givenSomeExceptionOccursWhenMappingResponseEntityToAStringThenExpectNullValue() throws Exception {
+		final Response response = mock(Response.class);
+
+		when(response.getEntity()).thenThrow(new NullPointerException());
+		final String actualResponseBodyString = ResponseEntityToStringMapper.map(response);
+		assertNull(actualResponseBodyString);
+
+	}
+
+}

--- a/src/test/java/com/shopify/model/ImageAltTextCreationRequestTest.java
+++ b/src/test/java/com/shopify/model/ImageAltTextCreationRequestTest.java
@@ -6,9 +6,6 @@ import java.util.List;
 
 import org.junit.Test;
 
-import com.shopify.model.ImageAltTextCreationRequest;
-import com.shopify.model.Metafield;
-
 public class ImageAltTextCreationRequestTest {
 
 	@Test

--- a/src/test/java/com/shopify/model/ShopifyFulfillmentCreationRequestTest.java
+++ b/src/test/java/com/shopify/model/ShopifyFulfillmentCreationRequestTest.java
@@ -9,10 +9,6 @@ import java.util.UUID;
 
 import org.junit.Test;
 
-import com.shopify.model.ShopifyFulfillment;
-import com.shopify.model.ShopifyFulfillmentCreationRequest;
-import com.shopify.model.ShopifyLineItem;
-
 public class ShopifyFulfillmentCreationRequestTest {
 
 	private static final List<String> SOME_TRACKING_URLS = Arrays.asList("https://ups.com/123", "https://ups.com/456");

--- a/src/test/java/com/shopify/model/ShopifyFulfillmentUpdateRequestTest.java
+++ b/src/test/java/com/shopify/model/ShopifyFulfillmentUpdateRequestTest.java
@@ -9,10 +9,6 @@ import java.util.UUID;
 
 import org.junit.Test;
 
-import com.shopify.model.ShopifyFulfillment;
-import com.shopify.model.ShopifyFulfillmentUpdateRequest;
-import com.shopify.model.ShopifyLineItem;
-
 public class ShopifyFulfillmentUpdateRequestTest {
 
 	private static final List<String> SOME_TRACKING_URLS = Arrays.asList("123.com");

--- a/src/test/java/com/shopify/model/ShopifyInventoryLevelRootTest.java
+++ b/src/test/java/com/shopify/model/ShopifyInventoryLevelRootTest.java
@@ -4,9 +4,6 @@ import static org.junit.Assert.assertSame;
 
 import org.junit.Test;
 
-import com.shopify.model.ShopifyInventoryLevel;
-import com.shopify.model.ShopifyInventoryLevelRoot;
-
 public class ShopifyInventoryLevelRootTest {
 
 	@Test

--- a/src/test/java/com/shopify/model/ShopifyInventoryLevelTest.java
+++ b/src/test/java/com/shopify/model/ShopifyInventoryLevelTest.java
@@ -4,8 +4,6 @@ import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
 
-import com.shopify.model.ShopifyInventoryLevel;
-
 public class ShopifyInventoryLevelTest {
 
 	@Test

--- a/src/test/java/com/shopify/model/ShopifyProductMetafieldCreationRequestTest.java
+++ b/src/test/java/com/shopify/model/ShopifyProductMetafieldCreationRequestTest.java
@@ -6,9 +6,6 @@ import java.util.UUID;
 
 import org.junit.Test;
 
-import com.shopify.model.MetafieldValueType;
-import com.shopify.model.ShopifyProductMetafieldCreationRequest;
-
 public class ShopifyProductMetafieldCreationRequestTest {
 
 	private static final String SOME_PRODUCT_ID = UUID.randomUUID().toString();

--- a/src/test/java/com/shopify/model/ShopifyProductTest.java
+++ b/src/test/java/com/shopify/model/ShopifyProductTest.java
@@ -7,9 +7,6 @@ import java.util.List;
 
 import org.junit.Test;
 
-import com.shopify.model.Option;
-import com.shopify.model.ShopifyProduct;
-
 public class ShopifyProductTest {
 
 	@Test

--- a/src/test/java/com/shopify/model/ShopifyRecurringApplicationChargeCreationRequestTest.java
+++ b/src/test/java/com/shopify/model/ShopifyRecurringApplicationChargeCreationRequestTest.java
@@ -1,15 +1,12 @@
 package com.shopify.model;
 
-import org.junit.Test;
-
-import com.shopify.model.ShopifyRecurringApplicationCharge;
-import com.shopify.model.ShopifyRecurringApplicationChargeCreationRequest;
-
-import java.math.BigDecimal;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+
+import java.math.BigDecimal;
+
+import org.junit.Test;
 
 public class ShopifyRecurringApplicationChargeCreationRequestTest {
 

--- a/src/test/java/com/shopify/model/ShopifyVariantMetafieldCreationRequestTest.java
+++ b/src/test/java/com/shopify/model/ShopifyVariantMetafieldCreationRequestTest.java
@@ -6,9 +6,6 @@ import java.util.UUID;
 
 import org.junit.Test;
 
-import com.shopify.model.MetafieldValueType;
-import com.shopify.model.ShopifyVariantMetafieldCreationRequest;
-
 public class ShopifyVariantMetafieldCreationRequestTest {
 
 	private static final String SOME_VARIANT_ID = UUID.randomUUID().toString();

--- a/src/test/java/com/shopify/model/ShopifyVariantRequestOption1ComparatorTest.java
+++ b/src/test/java/com/shopify/model/ShopifyVariantRequestOption1ComparatorTest.java
@@ -7,10 +7,6 @@ import java.math.BigDecimal;
 
 import org.junit.Test;
 
-import com.shopify.model.ShopifyVariantCreationRequest;
-import com.shopify.model.ShopifyVariantRequest;
-import com.shopify.model.ShopifyVariantRequestOption1Comparator;
-
 public class ShopifyVariantRequestOption1ComparatorTest {
 
 	private static final int ZERO = 0;

--- a/src/test/java/com/shopify/model/adapters/CurrencyAdapterTest.java
+++ b/src/test/java/com/shopify/model/adapters/CurrencyAdapterTest.java
@@ -8,8 +8,6 @@ import java.util.Currency;
 import org.junit.Before;
 import org.junit.Test;
 
-import com.shopify.model.adapters.CurrencyAdapter;
-
 public class CurrencyAdapterTest {
 
 	private CurrencyAdapter currencyAdapter;

--- a/src/test/java/com/shopify/model/adapters/DateTimeAdapterTest.java
+++ b/src/test/java/com/shopify/model/adapters/DateTimeAdapterTest.java
@@ -8,8 +8,6 @@ import org.joda.time.DateTimeZone;
 import org.junit.Before;
 import org.junit.Test;
 
-import com.shopify.model.adapters.DateTimeAdapter;
-
 public class DateTimeAdapterTest {
 
 	private DateTimeAdapter dateTimeAdapter;

--- a/src/test/java/com/shopify/model/adapters/EscapedStringAdapterTest.java
+++ b/src/test/java/com/shopify/model/adapters/EscapedStringAdapterTest.java
@@ -5,8 +5,6 @@ import static org.junit.Assert.assertEquals;
 import org.junit.Before;
 import org.junit.Test;
 
-import com.shopify.model.adapters.EscapedStringAdapter;
-
 public class EscapedStringAdapterTest {
 
 	private static final String UNESCAPED_STRING = "& & & I love this product & & &";

--- a/src/test/java/com/shopify/model/adapters/InventoryPolicyAdapterTest.java
+++ b/src/test/java/com/shopify/model/adapters/InventoryPolicyAdapterTest.java
@@ -6,7 +6,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 import com.shopify.model.InventoryPolicy;
-import com.shopify.model.adapters.InventoryPolicyAdapter;
 
 public class InventoryPolicyAdapterTest {
 

--- a/src/test/java/com/shopify/model/adapters/MetafieldValueTypeAdapterTest.java
+++ b/src/test/java/com/shopify/model/adapters/MetafieldValueTypeAdapterTest.java
@@ -6,7 +6,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 import com.shopify.model.MetafieldValueType;
-import com.shopify.model.adapters.MetafieldValueTypeAdapter;
 
 public class MetafieldValueTypeAdapterTest {
 

--- a/src/test/java/com/shopify/model/adapters/OrderRiskRecommendationAdapterTest.java
+++ b/src/test/java/com/shopify/model/adapters/OrderRiskRecommendationAdapterTest.java
@@ -6,7 +6,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 import com.shopify.model.OrderRiskRecommendation;
-import com.shopify.model.adapters.OrderRiskRecommendationAdapter;
 
 public class OrderRiskRecommendationAdapterTest {
 

--- a/src/test/java/com/shopify/model/adapters/TagsAdapterTest.java
+++ b/src/test/java/com/shopify/model/adapters/TagsAdapterTest.java
@@ -12,8 +12,6 @@ import java.util.Set;
 import org.junit.Before;
 import org.junit.Test;
 
-import com.shopify.model.adapters.TagsAdapter;
-
 public class TagsAdapterTest {
 
 	private static final Set<String> TAGS = new HashSet<>(Arrays.asList("tag1", "tag2", "tag3"));


### PR DESCRIPTION
The readEntity(String.class) specifically around strings was closing the buffer not allowing any other strings to read from it. It said that it is cached within the getEntity method. After messing with this a little bit, i just read from this directly to prevent that automatic closing of stream.