### PR TITLE
Support Spring Boot 2 and newer versions of jackson/jersey #35

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
 		<java.version>1.8</java.version>
 		<junit.version>4.13.1</junit.version>
 		<slf4j.version>1.7.22</slf4j.version>
-		<jersey.version>2.25.1</jersey.version>
+		<jersey.version>2.33</jersey.version>
 		<pitest.version>1.4.3</pitest.version>
 		<jacoco.version>0.8.2</jacoco.version>
 	</properties>
@@ -75,9 +75,14 @@
 			<version>${jersey.version}</version>
 		</dependency>
 		<dependency>
+			<groupId>org.glassfish.jersey.inject</groupId>
+			<artifactId>jersey-hk2</artifactId>
+			<version>${jersey.version}</version>
+		</dependency>
+		<dependency>
 			<groupId>com.fasterxml.jackson.jaxrs</groupId>
 			<artifactId>jackson-jaxrs-json-provider</artifactId>
-			<version>2.4.0</version>
+			<version>2.12.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.glassfish.jersey.media</groupId>

--- a/src/main/java/com/shopify/ShopifySdk.java
+++ b/src/main/java/com/shopify/ShopifySdk.java
@@ -19,6 +19,7 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 
+import com.shopify.mappers.ObjectMapperProvider;
 import org.apache.commons.lang3.StringUtils;
 import org.glassfish.jersey.client.ClientProperties;
 import org.glassfish.jersey.jackson.JacksonFeature;
@@ -1047,11 +1048,7 @@ public class ShopifySdk {
 	}
 
 	private static Client buildClient() {
-		final ObjectMapper mapper = ShopifySdkObjectMapper.buildMapper();
-		final JacksonJaxbJsonProvider provider = new JacksonJaxbJsonProvider();
-		provider.setMapper(mapper);
-
-		return ClientBuilder.newClient().register(JacksonFeature.class).register(provider);
+		return ClientBuilder.newClient().register(JacksonFeature.class).register(ObjectMapperProvider.class);
 	}
 
 	public class ShopifySdkRetryListener implements RetryListener {

--- a/src/main/java/com/shopify/mappers/ObjectMapperProvider.java
+++ b/src/main/java/com/shopify/mappers/ObjectMapperProvider.java
@@ -1,0 +1,20 @@
+package com.shopify.mappers;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import javax.ws.rs.ext.ContextResolver;
+import javax.ws.rs.ext.Provider;
+
+@Provider
+public class ObjectMapperProvider implements ContextResolver<ObjectMapper> {
+    private final ObjectMapper objectMapper;
+
+    public ObjectMapperProvider() {
+        objectMapper = ShopifySdkObjectMapper.buildMapper();
+    }
+
+    @Override
+    public ObjectMapper getContext(Class<?> aClass) {
+        return objectMapper;
+    }
+}


### PR DESCRIPTION
Hello,

This is a quick and dirty first pass for issue #35 and a way for me to personally address running into #32.

I'm not very familiar with Shopify's API, or this project, but at least the specific issue in #32 was simply that newer versions of Jersey don't seem to respect the custom `JacksonJaxbJsonProvider` you were using to get an `ObjectMapper` with `FAIL_ON_UNKNOWN_PROPERTIES` disabled.

This commit  switches to using a ContextResolver to provide the custom ObjectMapper generated by ShopifySdkObjectMapper.buildMapper() instead, which appears to work fine with newer versions of Jersey.

I did notice two tests were failing, although I didn't try them before hand to see if they were previously broken or this change breaks them.

Specifically, in `givenSomeValidAccessTokenAndSubdomainAndValidRequestWhenUpdatingVariantThenUpdateAndReturnVariant` it appears that the test is doing some json-as-string comparisons. The order of the last two fields that I was getting back was swapped, but perhaps this it is a little brittle to compare json responses as strings given the content is still the same:

```final String expectedRequestBodyString = "{\"variant\":{\"id\":\"98746868985974\",\"title\":\"UK 8\",\"price\":10.00,\"barcode\":\"459876235897\",\"position\":0,\"grams\":0,\"requires_shipping\":false,\"taxable\":false}}";
		
final String receivedRequestBodyStringCausingFailure = "{\"variant\":{\"id\":\"98746868985974\",\"title\":\"UK 8\",\"price\":10.00,\"barcode\":\"459876235897\",\"position\":0,\"grams\":0,\"taxable\":false,\"requires_shipping\":false}}";
```

Note that I also did not attempt to provide any additional tests / code coverage per your contributing guidelines. I'm happy for you to use this as a basis for having your implementation work with newer versions of Jersey, but unfortunately I don't have the time to investigate your specific tests/code coverage methodology.

Hope this helps!
Marcus